### PR TITLE
wrap DecryptContentKey in try/catch to prevent erroring out

### DIFF
--- a/CikExtractor/Program.cs
+++ b/CikExtractor/Program.cs
@@ -137,17 +137,24 @@ internal sealed class DumpCommand : Command<DumpCommand.Settings>
 
             foreach (var pair in license.PackedContentKeys)
             {
-                var contentKey = Crypto.DecryptContentKey(deviceKey, pair.Value);
-                var filePath = Path.Join(cikFolderPath, $"{pair.Key}.cik");
+                try
+                {
+                    var contentKey = Crypto.DecryptContentKey(deviceKey, pair.Value);
+                    var filePath = Path.Join(cikFolderPath, $"{pair.Key}.cik");
 
-                File.WriteAllBytes(filePath,
-                    pair.Key
-                        .ToByteArray()
-                        .Concat(contentKey)
-                        .ToArray());
+                    File.WriteAllBytes(filePath,
+                        pair.Key
+                            .ToByteArray()
+                            .Concat(contentKey)
+                            .ToArray());
 
-                var keyNode = packageNode.AddNode($":key: [blue]{pair.Key}[/]");
-                keyNode.AddNode($"[white bold]Key[/]: [green bold]{Convert.ToHexString(contentKey)}[/]");
+                    var keyNode = packageNode.AddNode($":key: [blue]{pair.Key}[/]");
+                    keyNode.AddNode($"[white bold]Key[/]: [green bold]{Convert.ToHexString(contentKey)}[/]");
+                } catch (Exception ex)
+                {
+                    var keyNode = packageNode.AddNode($":key: [blue]{pair.Key}[/]");
+                    keyNode.AddNode($"[red bold]Error[/]: [green bold]{ex.Message}[/]");
+                }
             }
         }
 


### PR DESCRIPTION
Sometimes on My Machine unsealing certain content instance keys fails, a complete guess is this is as a result of uninstalling or losing access to a license (GP expiry maybe?). This previously prevented the entire process from working. This PR allows it to complete dumping keys, only skipping over ones that fail to decrypt.

Previous output:
```
INFO: Loading entries from registry...
INFO: Registry loaded.
INFO: Reading device key from snip\deviceKey.txt.
INFO: Successfully loaded device key from file.
Error: checksum failed
```

New output:
```
INFO: Loading entries from registry...
INFO: Registry loaded.
INFO: Reading device key from snip\deviceKey.txt.
INFO: Successfully loaded device key from file.
??
├── ?? app1
│   ├── License Type: App
│   └── ?? key1
│       └── Key: snip
├── ?? app2
│   ├── License Type: App
│   └── ?? key2
│       └── Error: checksum failed
├── ?? app3
│   ├── License Type: App
│   └── ?? key3
│       └── Key: snip
```
